### PR TITLE
Add dask_optuna.optimize function

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ with dask.distributed.Client() as client:
     # Create a study using Dask-compatible storage
     study = optuna.create_study(storage=dask_optuna.DaskStorage())
     # Optimize in parallel on your Dask cluster
-    dask_optuna.optimize(study, objective, n_trials=100)
+    dask_optuna.optimize(study, objective, n_trials=100, batch_size=10)
     print(f"best_params = {study.best_params}")
 ```

--- a/README.md
+++ b/README.md
@@ -11,29 +11,17 @@ Dask-Optuna helps improve integration between [Optuna](https://optuna.org/) and 
 
 ```python
 import optuna
-from dask.distributed import Client, wait
+import dask.distributed
 import dask_optuna
-
 
 def objective(trial):
     x = trial.suggest_uniform("x", -10, 10)
     return (x - 2) ** 2
 
-
-def _optimize(storage=None):
-    dask_storage = dask_optuna.DaskStorage(storage=storage)
-    study = optuna.load_study(study_name="foo", storage=dask_storage)
-    study.optimize(objective, n_trials=10)
-
-
-with Client() as client:
-    dask_storage = dask_optuna.DaskStorage()
-    study = optuna.create_study(
-        study_name="foo", storage=dask_storage, load_if_exists=True
-    )
-    futures = [client.submit(_optimize, pure=False) for _ in range(10)]
-    wait(futures)
-
-    study = optuna.load_study(study_name="foo", storage=dask_storage)
-    print(f"study = {study}")
+with dask.distributed.Client() as client:
+    # Create a study using Dask-compatible storage
+    study = optuna.create_study(storage=dask_optuna.DaskStorage())
+    # Optimize in parallel on your Dask cluster
+    dask_optuna.optimize(study, objective, n_trials=100)
+    print(f"best_params = {study.best_params}")
 ```

--- a/dask_optuna/__init__.py
+++ b/dask_optuna/__init__.py
@@ -1,1 +1,2 @@
 from .storage import DaskStorage, OptunaSchedulerExtension
+from .optimize import optimize

--- a/dask_optuna/optimize.py
+++ b/dask_optuna/optimize.py
@@ -1,0 +1,74 @@
+from typing import Callable
+
+import optuna
+from distributed import Client, default_client, wait
+
+from .storage import DaskStorage
+
+ObjectiveFuncType = Callable[[optuna.Trial], float]
+
+
+def _optimize_batch(study_name, objective, storage_name=None, n_trials=None):
+    dask_storage = DaskStorage(storage=storage_name)
+    study = optuna.load_study(study_name=study_name, storage=dask_storage)
+    study.optimize(objective, n_trials=n_trials)
+
+
+def get_batch_sizes(n_trials, batch_size=None):
+    if batch_size is None:
+        # In not specified, use a single batch
+        return [n_trials]
+
+    batch_sizes = [batch_size] * (n_trials // batch_size)
+    if n_trials % batch_size:
+        batch_sizes += [n_trials % batch_size]
+    return batch_sizes
+
+
+def optimize(
+    study: optuna.Study,
+    func: ObjectiveFuncType,
+    n_trials: int = 100,
+    batch_size: int = None,
+    client: Client = None,
+) -> None:
+    """ Optimize an objective function
+
+    Trials are batched and each batch is run in parllel on a Dask cluster.
+
+    Parameters
+    ----------
+    study
+        Optuna ``Study`` to use.
+    func
+        Objective function to optimize
+    n_trials
+        Number of optimization trials to perform. Defaults to 100.
+    batch_size
+        Number of trials to perform per batch. Defaults to a single batch of size ``n_trials``.
+    client
+        Dask ``Client`` connected to your cluster. If not provided, ``dask.distributed.default_client()``
+        if used to determine which ``Client`` should be used.
+    """
+
+    client = client or default_client()
+    storage = study._storage
+    if not isinstance(storage, DaskStorage):
+        raise TypeError(
+            f"Expected storage to be of type dask_optuna.DaskStorage but got {type(storage)} instead"
+        )
+    storage_name = storage.storage
+    study_name = study.study_name
+
+    futures = [
+        client.submit(
+            _optimize_batch,
+            study_name=study_name,
+            objective=func,
+            storage_name=storage_name,
+            n_trials=n,
+            pure=False,
+        )
+        for n in get_batch_sizes(n_trials, batch_size)
+    ]
+    wait(futures)

--- a/dask_optuna/optimize.py
+++ b/dask_optuna/optimize.py
@@ -32,7 +32,7 @@ def optimize(
     batch_size: int = None,
     client: Client = None,
 ) -> None:
-    """ Optimize an objective function
+    """Optimize an objective function
 
     Trials are batched and each batch is run in parllel on a Dask cluster.
 

--- a/dask_optuna/tests/test_optimize.py
+++ b/dask_optuna/tests/test_optimize.py
@@ -1,0 +1,42 @@
+import pytest
+import optuna
+from distributed import Client
+from distributed.utils_test import gen_cluster
+
+import dask_optuna
+from dask_optuna.optimize import get_batch_sizes
+
+
+def test_get_batch_sizes():
+    assert get_batch_sizes(n_trials=10, batch_size=3) == [3, 3, 3, 1]
+    assert get_batch_sizes(n_trials=10, batch_size=5) == [5, 5]
+    assert get_batch_sizes(n_trials=10, batch_size=None) == [10]
+    assert get_batch_sizes(n_trials=10, batch_size=10) == [10]
+
+
+def objective(trial):
+    x = trial.suggest_uniform("x", -10, 10)
+    return (x - 2) ** 2
+
+
+@pytest.mark.parametrize("processes", [True, False])
+def test_optimize_sync(processes):
+    with Client(processes=processes):
+        study = optuna.create_study(storage=dask_optuna.DaskStorage())
+        dask_optuna.optimize(
+            study, objective, n_trials=10, batch_size=5,
+        )
+        assert len(study.trials) == 10
+
+
+@gen_cluster(client=True)
+def test_storage_raises(c, s, a, b):
+    with pytest.raises(TypeError) as excinfo:
+        study = optuna.create_study()
+        dask_optuna.optimize(
+            study, objective, n_trials=10, batch_size=5,
+        )
+
+    output = str(excinfo.value)
+    assert "Expected" in output
+    assert "dask_optuna.DaskStorage" in output

--- a/dask_optuna/tests/test_optimize.py
+++ b/dask_optuna/tests/test_optimize.py
@@ -24,7 +24,10 @@ def test_optimize_sync(processes):
     with Client(processes=processes):
         study = optuna.create_study(storage=dask_optuna.DaskStorage())
         dask_optuna.optimize(
-            study, objective, n_trials=10, batch_size=5,
+            study,
+            objective,
+            n_trials=10,
+            batch_size=5,
         )
         assert len(study.trials) == 10
 
@@ -34,7 +37,10 @@ def test_storage_raises(c, s, a, b):
     with pytest.raises(TypeError) as excinfo:
         study = optuna.create_study()
         dask_optuna.optimize(
-            study, objective, n_trials=10, batch_size=5,
+            study,
+            objective,
+            n_trials=10,
+            batch_size=5,
         )
 
     output = str(excinfo.value)


### PR DESCRIPTION
This wraps batch submitting trials to a Dask cluster in a utility `dask_optuna.optimize` function with a similar signature as `optuna.Study.optimize`:

```python
import optuna
import dask.distributed
import dask_optuna

def objective(trial):
    x = trial.suggest_uniform("x", -10, 10)
    return (x - 2) ** 2

with dask.distributed.Client() as client:
    # Create a study using Dask-compatible storage
    study = optuna.create_study(storage=dask_optuna.DaskStorage())
    # Optimize in parallel on your Dask cluster
    dask_optuna.optimize(study, objective, n_trials=100)
    print(f"best_params = {study.best_params}")
```

NOTE: Currently this only works with synchronous `Client`s, but it's a start.

Longer-term, since Optuna uses `joblib` under the hood, one could use `optuna.Study.optimize` inside a `joblib.parallel_backend("dask")` context manager to farm out trials to a Dask cluster. However, today this results in non-pickleable objects being `joblib.delayed`, so the joblib approach doesn't work across multiple processes. 