### PR TITLE
Remove batch_size from optimize

### DIFF
--- a/dask_optuna/tests/test_optimize.py
+++ b/dask_optuna/tests/test_optimize.py
@@ -4,15 +4,7 @@ from distributed import Client
 from distributed.utils_test import gen_cluster
 
 import dask_optuna
-from dask_optuna.optimize import get_batch_sizes
 from .utils import get_storage_url
-
-
-def test_get_batch_sizes():
-    assert get_batch_sizes(n_trials=10, batch_size=3) == [3, 3, 3, 1]
-    assert get_batch_sizes(n_trials=10, batch_size=5) == [5, 5]
-    assert get_batch_sizes(n_trials=10, batch_size=None) == [10]
-    assert get_batch_sizes(n_trials=10, batch_size=10) == [10]
 
 
 def objective(trial):
@@ -31,7 +23,6 @@ def test_optimize_sync(storage_specifier, processes):
                 study,
                 objective,
                 n_trials=10,
-                batch_size=5,
             )
             assert len(study.trials) == 10
 
@@ -44,7 +35,6 @@ def test_storage_raises(c, s, a, b):
             study,
             objective,
             n_trials=10,
-            batch_size=5,
         )
 
     output = str(excinfo.value)


### PR DESCRIPTION
Submitting trials in batches instead of individually doesn't improve performance noticeably for ~a few thousand trials. As I'd prefer to keep things simple for now, this PR removes the `batch_size` option from `dask_optuna.optimize` and instead submits trials individually. It'll be straightforward to add this back if there are users that end up wanting to use trial batches