### PR TITLE
Wait for Coiled cluster workers to arrive

### DIFF
--- a/examples/xgboost-coiled.py
+++ b/examples/xgboost-coiled.py
@@ -20,7 +20,7 @@ from dask.distributed import Client
 import coiled
 import dask_optuna
 
-optuna.logging.set_verbosity(optuna.logging.WARN)
+optuna.logging.set_verbosity(optuna.logging.WARNING)
 
 
 def objective(trial):
@@ -65,6 +65,7 @@ if __name__ == "__main__":
     with coiled.Cluster(n_workers=5, configuration="jrbourbeau/optuna") as cluster:
         with Client(cluster) as client:
             print(f"Dask dashboard is available at {client.dashboard_link}")
+            client.wait_for_workers(5)
 
             storage = dask_optuna.DaskStorage("sqlite:///coiled-example.db")
             study = optuna.create_study(storage=storage, direction="maximize")


### PR DESCRIPTION
When starting up, Joblib polls the number of workers in a cluster to determine the number of tasks that can run in parallel. If this happens before all the workers in a cluster arrive, then the number of workers Joblib thinks the cluster have can be a large underestimate, resulting in an under-utilization of the cluster. As a workaround, this PR adds an update to wait for all workers to arrive before using Joblib. 

(thanks to @mrocklin for noticing this)